### PR TITLE
Bumped libxmljs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "gulp-util": "~3.0.1",
-    "through2": "~1.1.1",
-    "libxmljs": "~0.12.0"
+    "libxmljs": "^0.13.0",
+    "through2": "~1.1.1"
   },
   "devDependencies": {
     "gulp": "*",


### PR DESCRIPTION
This version bump removed a 'Segmentation Fault' message when using with Node.js 0.12.0.