### PR TITLE
Adds namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gulp.src("./manifest.xml")
   .pipe(xeditor([
     {path: '//xmlns:name', text: 'new names'},
     {path: '//xmlns:version', attr: {'major': '2'}}
-  ], http://www.w3.org/ns/widgets))
+  ], 'http://www.w3.org/ns/widgets'))
   .pipe(gulp.dest("./dest"));
 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ gulp.src("./manifest.xml")
   ]))
   .pipe(gulp.dest("./dest"));
 
+/*
+  edit XML document by using user specific object using a namespace
+*/
+gulp.src("./manifest.xml")
+  .pipe(xeditor([
+    {path: '//xmlns:name', text: 'new names'},
+    {path: '//xmlns:version', attr: {'major': '2'}}
+  ], http://www.w3.org/ns/widgets))
+  .pipe(gulp.dest("./dest"));
+
 
 /*
   edit XML document by using user specific function

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var xmljs       = require('libxmljs');
 var through     = require('through2');
 var PluginError = require('gulp-util').PluginError;
 
-module.exports = function (editor) {
+module.exports = function (editor, namespace) {
 
   // edit XML document by user specific function
   function editByFunction(xmlDoc, xmljs) {
@@ -15,7 +15,7 @@ module.exports = function (editor) {
   function editByObject(xmlDoc, xmljs, ee) {
 
     editor.forEach(function(ed) {
-      var elem = xmlDoc.get(ed.path);
+      var elem = (namespace == undefined) ? xmlDoc.get(ed.path) : xmlDoc.get(ed.path, namespace);
       if (!elem || !(elem instanceof xmljs.Element)) {
         ee.emit('error', new PluginError('gulp-xml-editor', 'Can\'t find element at "' + ed.path + '"'));
         return;
@@ -72,3 +72,4 @@ module.exports = function (editor) {
   });
 
 };
+


### PR DESCRIPTION
This provides an optional parameter to specify the xml namespace for xml documents that utilize namespaces. If the namespace parameter isnt provided, it is ignored and the original behavior takes over.

See the modified Readme.md to see an example of utilizing a namespace using this plugin

also see http://blog.maxcnunes.net/2014/12/06/libxmljs-finding-xml-elements-with-namespaces-using-xpath/ for further namespace capabilities